### PR TITLE
Add `rust-analyzer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and depend on particular LSP servers functioning.
 ## Quickstart
 
 ```
-lpm add https://github.com/adamharrison/lite-xl-lsp-servers.git && lpm install lsp_c lsp_lua
+lpm add https://github.com/adamharrison/lite-xl-lsp-servers.git && lpm install lsp_c lsp_lua lsp_rust
 ```
 
 ## Languages Supported
@@ -20,4 +20,5 @@ The following languages are supported, bundled with their particular language se
 | :------------------------------------------- | :------------------- | :-------------------------------------------------------------- | :--------
 | [lsp_lua](/plugins/lsp_lua.lua?raw=1)        | lua                  | [sumneko_lua](https://github.com/sumneko/lua-language-server)   | Linux, Mac, Windows
 | [lsp_c](/plugins/lsp_c.lua?raw=1)            | C, C++, Objective-C  | [clangd](https://github.com/clangd/clangd)                      | Linux, Mac, Windows
+| [lsp_rust](/plugins/lsp_rust.lua?raw=1)      | Rust                 | [rust-analyzer](https://github.com/rust-lang/rust-analyzer)     | Linux, Mac, Windows
 

--- a/manifest.json
+++ b/manifest.json
@@ -43,5 +43,28 @@
       }
     ],
     "dependencies": { "lsp": {} }
+  }, {
+    "id": "lsp_rust",
+    "description": "LSP support for Rust via rust-analyzer.",
+    "path": "plugins/lsp_rust.lua",
+    "version": "20230807",
+    "files": [
+      {
+        "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-08-07/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+        "arch": "x86_64-linux",
+        "checksum": "0437f9ba1801aaf975ddff484959bdaf66166a3d73030112cb8e2ce239b6a188"
+      },
+      {
+        "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-08-07/rust-analyzer-x86_64-apple-darwin.gz",
+        "arch": "x86_64-darwin",
+        "checksum": "54082be4c2b50b90bace232338fb2d8b23b491f1d7d2bafe201e63e471df10f0"
+      },
+      {
+        "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-08-07/rust-analyzer-x86_64-pc-windows-msvc.zip",
+        "arch": "x86_64-windows",
+        "checksum": "35d4e330968255f5a3bbf207ff0a3c57466c040913e095d055d05fddb2e2ff00"
+      }
+    ],
+    "dependencies": { "language_rust": {}, "lsp": {} }
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -47,22 +47,22 @@
     "id": "lsp_rust",
     "description": "LSP support for Rust via rust-analyzer.",
     "path": "plugins/lsp_rust.lua",
-    "version": "20230807",
+    "version": "20230814",
     "files": [
       {
-        "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-08-07/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+        "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-08-14/rust-analyzer-x86_64-unknown-linux-gnu.gz",
         "arch": "x86_64-linux",
-        "checksum": "0437f9ba1801aaf975ddff484959bdaf66166a3d73030112cb8e2ce239b6a188"
+        "checksum": "1bdc7a7f67bf71530e679ce2af5788050084b1e9773aeb34561711126996647e"
       },
       {
-        "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-08-07/rust-analyzer-x86_64-apple-darwin.gz",
+        "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-08-14/rust-analyzer-x86_64-apple-darwin.gz",
         "arch": "x86_64-darwin",
-        "checksum": "54082be4c2b50b90bace232338fb2d8b23b491f1d7d2bafe201e63e471df10f0"
+        "checksum": "695d95989ed6dfec8b0cfa7d832b1a6226075e19a3259f3b5d21f6c5e83c972e"
       },
       {
-        "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-08-07/rust-analyzer-x86_64-pc-windows-msvc.zip",
+        "url": "https://github.com/rust-lang/rust-analyzer/releases/download/2023-08-14/rust-analyzer-x86_64-pc-windows-msvc.zip",
         "arch": "x86_64-windows",
-        "checksum": "35d4e330968255f5a3bbf207ff0a3c57466c040913e095d055d05fddb2e2ff00"
+        "checksum": "fa4d819d3521ce4697ee1d28edb761e7e7fac4f5d2d418b47d8b68ffdbb52c2d"
       }
     ],
     "dependencies": { "language_rust": {}, "lsp": {} }

--- a/plugins/lsp_rust.lua
+++ b/plugins/lsp_rust.lua
@@ -1,0 +1,17 @@
+-- mod-version:3
+
+local lspconfig = require "plugins.lsp.config"
+
+local installed_path = USERDIR .. PATHSEP .. "plugins" .. PATHSEP .. "lsp_rust"
+local filename
+if PLATFORM == "Windows" then
+  filename = "rust-analyzer.exe"
+elseif PLATFORM == "Mac OS X" then
+  filename = "rust-analyzer-x86_64-apple-darwin"
+else
+  filename = "rust-analyzer-x86_64-unknown-linux-gnu"
+end
+
+lspconfig.rust_analyzer.setup({
+  command = { installed_path .. PATHSEP .. filename }
+})


### PR DESCRIPTION
Needs that lite-xl/lite-xl-plugin-manager#37 gets fixed.

More platforms could be added.