### PR TITLE
Add python lsp support via Pyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ The following languages are supported, bundled with their particular language se
 | [lsp_rust](/plugins/lsp_rust.lua?raw=1)                      | Rust                 | [rust-analyzer](https://github.com/rust-lang/rust-analyzer)     | Linux, Mac, Windows
 | [lsp_tex](/plugins/lsp_tex.lua?raw=1)                        | TeX                  | [texlab](https://github.com/latex-lsp/texlab)                   | Linux, Mac, Windows
 | [lsp_zig](/plugins/lsp_zig.lua?raw=1)                        | Zig                  | [zls](https://github.com/zigtools/zls)                          | Linux, Mac, Windows
+
+## Additional libraries
+
+These libraries are dependencies of som language servers (automatic installation with `lpm`).
+
+| Library                                                      | Description                                 | Platforms
+| :----------------------------------------------------------- | :------------------------------------------ | :------------------
+| [nodejs](/libraries/nodejs.lua?raw=1)                        | NodeJs binaries for running javascript apps | Linux, Mac, Windows

--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ The following languages are supported, bundled with their particular language se
 | [lsp_c](/plugins/lsp_c.lua?raw=1)            | C, C++, Objective-C  | [clangd](https://github.com/clangd/clangd)                      | Linux, Mac, Windows
 | [lsp_rust](/plugins/lsp_rust.lua?raw=1)      | Rust                 | [rust-analyzer](https://github.com/rust-lang/rust-analyzer)     | Linux, Mac, Windows
 | [lsp_zig](/plugins/lsp_zig.lua?raw=1)        | Zig                  | [zls](https://github.com/zigtools/zls)                          | Linux, Mac, Windows
+| [lsp_python](/plugins/lsp_python.lua?raw=1)  | Python               | [pyright](https://github.com/Microsoft/pyright)                 | Linux, Mac, Windows
 

--- a/libraries/nodejs.lua
+++ b/libraries/nodejs.lua
@@ -2,19 +2,20 @@
 
 local info = {}
 
+info.path_lib = USERDIR .. PATHSEP .. "libraries" .. PATHSEP .. "nodejs"
 info.version = "node-v20.11.1"
 
+info.path_arch = {}
+info.path_arch["x86_64-linux"]   = info.version .. "-linux-x64"
+info.path_arch["x86_64-darwin"]  = info.version .. "-darwin-x64"
+info.path_arch["arm64-darwin"]   = info.version .. "-darwin-arm64"
+info.path_arch["x86_64-windows"] = info.version .. "-win-x64"
 
-if     ARCH == "x86_64-linux" then
-  info.path = info.version .. "-linux-x64"    .. PATHSEP .. "bin" .. PATHSEP .. "node"
-elseif ARCH == "x86_64-darwin" then
-  info.path = info.version .. "-darwin-x64"   .. PATHSEP .. "bin" .. PATHSEP .. "node"
-elseif ARCH == "arm64-darwin" then
-  info.path = info.version .. "-darwin-arm64" .. PATHSEP .. "bin" .. PATHSEP .. "node"
-elseif ARCH == "x86_64-windows" then
-  info.path = info.version .. "-win-x64"      .. PATHSEP .. "node.exe"
+if PLATFORM == "Windows" then
+  info.path_bin = info.path_lib .. PATHSEP .. info.path_arch[ARCH] .. PATHSEP .. "node.exe"
+else
+  info.path_bin = info.path_lib .. PATHSEP .. info.path_arch[ARCH] .. PATHSEP .. "bin" .. PATHSEP .. "node"
 end
-
 
 
 return info

--- a/libraries/nodejs.lua
+++ b/libraries/nodejs.lua
@@ -1,0 +1,20 @@
+-- mod-version:3
+
+local info = {}
+
+info.version = "node-v20.11.1"
+
+
+if     ARCH == "x86_64-linux" then
+  info.path = info.version .. "-linux-x64"    .. PATHSEP .. "bin" .. PATHSEP .. "node"
+elseif ARCH == "x86_64-darwin" then
+  info.path = info.version .. "-darwin-x64"   .. PATHSEP .. "bin" .. PATHSEP .. "node"
+elseif ARCH == "arm64-darwin" then
+  info.path = info.version .. "-darwin-arm64" .. PATHSEP .. "bin" .. PATHSEP .. "node"
+elseif ARCH == "x86_64-windows" then
+  info.path = info.version .. "-win-x64"      .. PATHSEP .. "node.exe"
+end
+
+
+
+return info

--- a/manifest.json
+++ b/manifest.json
@@ -142,9 +142,9 @@
     "mod_version": "3",
     "files": [
       {
-        "url": "https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-x64.tar.xz",
+        "url": "https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-x64.tar.gz",
         "arch": ["x86_64-linux"],
-        "checksum": "822780369d0ea309e7d218e41debbd1a03f8cdf354ebf8a4420e89f39cc2e612"
+        "checksum": "9556262f6cd4c020af027782afba31ca6d1a37e45ac0b56cecd2d5a4daf720e0"
       },
       {
         "url": "https://nodejs.org/dist/v20.11.0/node-v20.11.0-darwin-arm64.tar.gz",

--- a/manifest.json
+++ b/manifest.json
@@ -137,44 +137,45 @@
   },{
     "id": "nodejs",
     "description": "Official NodeJs builds.",
-    "version": "20.11.0",
+    "version": "20.11.1",
     "type": "library",
     "mod_version": "3",
+    "path": "libraries/nodejs.lua",
     "files": [
       {
-        "url": "https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-x64.tar.gz",
+        "url": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-x64.tar.gz",
         "arch": ["x86_64-linux"],
-        "checksum": "9556262f6cd4c020af027782afba31ca6d1a37e45ac0b56cecd2d5a4daf720e0"
+        "checksum": "bf3a779bef19452da90fb88358ec2c57e0d2f882839b20dc6afc297b6aafc0d7"
       },
       {
-        "url": "https://nodejs.org/dist/v20.11.0/node-v20.11.0-darwin-arm64.tar.gz",
+        "url": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-darwin-arm64.tar.gz",
         "arch": ["aarch64-darwin"],
-        "checksum": "94e443d007e2882f8e5aecc85d978f7591520dc3b642adc7583b3cb0b3fc37d7"
+        "checksum": "e0065c61f340e85106a99c4b54746c5cee09d59b08c5712f67f99e92aa44995d"
       },
       {
-        "url": "https://nodejs.org/dist/v20.11.0/node-v20.11.0-darwin-x64.tar.gz",
+        "url": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-darwin-x64.tar.gz",
         "arch": ["x86_64-darwin"],
-        "checksum": "c0ba02c905814258bd99a362027f8d4d2cc738218a9cf1dce2620e8735e3a80e"
+        "checksum": "c52e7fb0709dbe63a4cbe08ac8af3479188692937a7bd8e776e0eedfa33bb848"
       },
       {
-        "url": "https://nodejs.org/dist/v20.11.0/node-v20.11.0-win-x64.zip",
+        "url": "https://nodejs.org/dist/v20.11.1/node-v20.11.1-win-x64.zip",
         "arch": ["x86_64-windows"],
-        "checksum": "893115cd92ad27bf178802f15247115e93c0ef0c753b93dca96439240d64feb5"
+        "checksum": "bc032628d77d206ffa7f133518a6225a9c5d6d9210ead30d67e294ff37044bda"
       }
     ]
   },{
     "id": "lsp_python",
     "description": "LSP support for Python via Pyright.",
     "path": "plugins/lsp_python.lua",
-    "version": "1.1.350",
+    "version": "1.1.351",
     "files": [
       {
-        "url": "https://registry.npmjs.org/pyright/-/pyright-1.1.350.tgz",
+        "url": "https://registry.npmjs.org/pyright/-/pyright-1.1.351.tgz",
         "arch": ["x86_64-linux", "x86_64-windows", "x86_64-darwin", "aarch64-darwin"],
-        "checksum": "d3bc2b74950884c7e362df0f3728bb58c112f16f9a122d18ea177ba8c6845626"
+        "checksum": "a557e75b53fc851314c23ee9a167101fd0a9b9bf391f4a75f6315178b3f7760c"
       }
     ],
-    "dependencies": { "lsp": {}, "nodejs": {"optional": true} }
+    "dependencies": { "lsp": {}, "nodejs": {"optional": true}, "language_python": {} }
   },{
     "id": "lsp_quicklintjs",
     "description": "LSP support for Javascript via quick-lint-js (Linting only).",

--- a/manifest.json
+++ b/manifest.json
@@ -135,7 +135,7 @@
     ],
     "dependencies": { "language_tex": {}, "lsp": {} }
   },{
-    "id": "node",
+    "id": "nodejs",
     "description": "Official NodeJs builds.",
     "version": "20.11.0",
     "type": "library",
@@ -174,6 +174,6 @@
         "checksum": "d3bc2b74950884c7e362df0f3728bb58c112f16f9a122d18ea177ba8c6845626"
       }
     ],
-    "dependencies": { "language_python": {}, "lsp": {}, "node": {} }
+    "dependencies": { "language_python": {}, "lsp": {}, "nodejs": {} }
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -135,6 +135,34 @@
     ],
     "dependencies": { "language_tex": {}, "lsp": {} }
   },{
+    "id": "node",
+    "description": "Official NodeJs builds.",
+    "version": "20.11.0",
+    "type": "library",
+    "mod_version": "3",
+    "files": [
+      {
+        "url": "https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-x64.tar.xz",
+        "arch": ["x86_64-linux"],
+        "checksum": "822780369d0ea309e7d218e41debbd1a03f8cdf354ebf8a4420e89f39cc2e612"
+      },
+      {
+        "url": "https://nodejs.org/dist/v20.11.0/node-v20.11.0-darwin-arm64.tar.gz",
+        "arch": ["aarch64-darwin"],
+        "checksum": "94e443d007e2882f8e5aecc85d978f7591520dc3b642adc7583b3cb0b3fc37d7"
+      },
+      {
+        "url": "https://nodejs.org/dist/v20.11.0/node-v20.11.0-darwin-x64.tar.gz",
+        "arch": ["x86_64-darwin"],
+        "checksum": "c0ba02c905814258bd99a362027f8d4d2cc738218a9cf1dce2620e8735e3a80e"
+      },
+      {
+        "url": "https://nodejs.org/dist/v20.11.0/node-v20.11.0-win-x64.zip",
+        "arch": ["x86_64-windows"],
+        "checksum": "893115cd92ad27bf178802f15247115e93c0ef0c753b93dca96439240d64feb5"
+      }
+    ]
+  },{
     "id": "lsp_python",
     "description": "LSP support for Python via Pyright.",
     "path": "plugins/lsp_python.lua",
@@ -146,6 +174,6 @@
         "checksum": "d3bc2b74950884c7e362df0f3728bb58c112f16f9a122d18ea177ba8c6845626"
       }
     ],
-    "dependencies": { "language_python": {}, "lsp": {} }
+    "dependencies": { "language_python": {}, "lsp": {}, "node": {} }
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -174,6 +174,6 @@
         "checksum": "d3bc2b74950884c7e362df0f3728bb58c112f16f9a122d18ea177ba8c6845626"
       }
     ],
-    "dependencies": { "language_python": {}, "lsp": {}, "nodejs": {"optional": true} }
+    "dependencies": { "lsp": {}, "nodejs": {"optional": true} }
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -134,5 +134,18 @@
       }
     ],
     "dependencies": { "language_tex": {}, "lsp": {} }
+  },{
+    "id": "lsp_python",
+    "description": "LSP support for Python via Pyright.",
+    "path": "plugins/lsp_python.lua",
+    "version": "1.1.350",
+    "files": [
+      {
+        "url": "https://registry.npmjs.org/pyright/-/pyright-1.1.350.tgz",
+        "arch": ["x86_64-linux", "x86_64-windows", "x86_64-darwin", "aarch64-darwin"],
+        "checksum": "d3bc2b74950884c7e362df0f3728bb58c112f16f9a122d18ea177ba8c6845626"
+      }
+    ],
+    "dependencies": { "language_python": {}, "lsp": {} }
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -174,6 +174,6 @@
         "checksum": "d3bc2b74950884c7e362df0f3728bb58c112f16f9a122d18ea177ba8c6845626"
       }
     ],
-    "dependencies": { "language_python": {}, "lsp": {}, "nodejs": {} }
+    "dependencies": { "language_python": {}, "lsp": {}, "nodejs": {"optional": true} }
   }]
 }

--- a/plugins/lsp_python.lua
+++ b/plugins/lsp_python.lua
@@ -5,9 +5,8 @@ local common = require "core.common"
 local config = require "core.config"
 local core = require "core"
 
-local installed_path_plugin = USERDIR .. PATHSEP .. "plugins" .. PATHSEP .. "lsp_python"
-local installed_path_library = USERDIR .. PATHSEP .. "libraries" .. PATHSEP .. "nodejs" .. PATHSEP
 
+local installed_path_plugin = USERDIR .. PATHSEP .. "plugins" .. PATHSEP .. "lsp_python"
 local server_path = installed_path_plugin .. PATHSEP .. "package" .. PATHSEP .. "langserver.index.js"
 
 
@@ -15,11 +14,11 @@ local ok, node_info = pcall(require, "libraries.nodejs")
 local final_command
 
 if ok then
-  -- NodeJs installed with lpm, runs it instead.
-  final_command = {installed_path_library .. node_info.path, server_path, "--stdio"}
+  -- NodeJs installed with lpm, runs it.
+  final_command = {node_info.path_bin, server_path, "--stdio"}
   core.log("[lsp_python]: nodejs library found, using it to launch Pyright.")
 else
-  -- NodeJs not installed with lpm, then tries to use the system path variable.
+  -- NodeJs not installed with lpm, tries to use the system path variable.
   final_command = {"node", server_path, "--stdio"}
   core.log("[lsp_python]: nodejs library not found, trying to use the 'node' path variable.")
 end

--- a/plugins/lsp_python.lua
+++ b/plugins/lsp_python.lua
@@ -3,26 +3,35 @@
 local lspconfig = require "plugins.lsp.config"
 local common = require "core.common"
 local config = require "core.config"
+local core = require "core"
 
 local installed_path_plugin = USERDIR .. PATHSEP .. "plugins" .. PATHSEP .. "lsp_python"
+local node_version = "node-v20.11.0"
 local installed_path_library = USERDIR .. PATHSEP .. "libraries" .. PATHSEP .. "nodejs"
 
 local server_path = installed_path_plugin .. PATHSEP .. "package" .. PATHSEP .. "langserver.index.js"
 
 local node_path
-if PLATFORM == "Linux" or PLATFORM == "Mac OS X" then
-  node_path = installed_path_library .. PATHSEP .. "bin" .. PATHSEP .. "node"
-elseif PLATFORM == "Windows" then
-  node_path = installed_path_library .. PATHSEP .. "node.exe"
+if ARCH == "x86_64-linux" then
+  node_path = installed_path_library .. PATHSEP .. node_version .. "-linux-x64" .. PATHSEP .. "bin" .. PATHSEP .. "node"
+elseif ARCH == "x86_64-darwin" then
+  node_path = installed_path_library .. PATHSEP .. node_version .. "-darwin-x64" .. PATHSEP .. "bin" .. PATHSEP .. "node"
+elseif ARCH == "arm64-darwin" then
+  node_path = installed_path_library .. PATHSEP .. node_version .. "-darwin-arm64" .. PATHSEP .. "bin" .. PATHSEP .. "node"
+elseif ARCH == "x86_64-windows" then
+  node_path = installed_path_library .. PATHSEP .. node_version .. "-win-x64" .. PATHSEP .. "node.exe"
 end
 
 local final_command
+core.log(node_path)
 if system.get_file_info(node_path) == nil then
   -- NodeJs not installed with lpm, then tries to use the system path variable.
   final_command = {"node", server_path, "--stdio"}
+  core.log("[lsp_python]: nodejs library not found, trying to use the 'node' path variable.")
 else
   -- NodeJs installed with lpm, runs it instead.
   final_command = {node_path, server_path, "--stdio"}
+  core.log("[lsp_python]: nodejs library found, using it to launch Pyright.")
 end
 
 

--- a/plugins/lsp_python.lua
+++ b/plugins/lsp_python.lua
@@ -16,8 +16,16 @@ elseif PLATFORM == "Windows" then
   node_path = installed_path_library .. PATHSEP .. "node.exe"
 end
 
+local final_command
+if system.get_file_info(node_path) == nil then
+  -- NodeJs not installed with lpm, then tries to use the system path variable.
+  final_command = {"node", server_path, "--stdio"}
+else
+  -- NodeJs installed with lpm, runs it instead.
+  final_command = {node_path, server_path, "--stdio"}
+end
 
 
-lspconfig.pyright.setup(common.merge({
-  command = {node_path, server_path, "--stdio"}},
+lspconfig.pyright.setup(common.merge(
+  {command = final_command},
   config.plugins.lsp_python or {}))

--- a/plugins/lsp_python.lua
+++ b/plugins/lsp_python.lua
@@ -16,11 +16,11 @@ local final_command
 if ok then
   -- NodeJs installed with lpm, runs it.
   final_command = {node_info.path_bin, server_path, "--stdio"}
-  core.log("[lsp_python]: nodejs library found, using it to launch Pyright.")
+  core.log_quiet("[lsp_python]: nodejs library found, using it to launch Pyright.")
 else
   -- NodeJs not installed with lpm, tries to use the system path variable.
   final_command = {"node", server_path, "--stdio"}
-  core.log("[lsp_python]: nodejs library not found, trying to use the 'node' path variable.")
+  core.log_quiet("[lsp_python]: nodejs library not found, trying to use the 'node' path variable.")
 end
 
 

--- a/plugins/lsp_python.lua
+++ b/plugins/lsp_python.lua
@@ -4,8 +4,20 @@ local lspconfig = require "plugins.lsp.config"
 local common = require "core.common"
 local config = require "core.config"
 
-local installed_path = USERDIR .. PATHSEP .. "plugins" .. PATHSEP .. "lsp_python"
+local installed_path_plugin = USERDIR .. PATHSEP .. "plugins" .. PATHSEP .. "lsp_python"
+local installed_path_library = USERDIR .. PATHSEP .. "libraries" .. PATHSEP .. "node"
+
+local server_path = installed_path_plugin .. PATHSEP .. "package" .. PATHSEP .. "langserver.index.js"
+
+local node_path
+if PLATFORM == "Linux" or PLATFORM == "Mac OS X" then
+  node_path = installed_path_library .. PATHSEP .. "bin" .. PATHSEP .. "node"
+elseif PLATFORM == "Windows" then
+  node_path = installed_path_library .. PATHSEP .. "node.exe"
+end
+
+
 
 lspconfig.pyright.setup(common.merge({
-  command = {installed_path .. PATHSEP .. "package" .. PATHSEP .. "langserver.index.js", "--stdio"}
-}, config.plugins.lsp_python or {}))
+  command = {node_path, server_path, "--stdio"}},
+  config.plugins.lsp_python or {}))

--- a/plugins/lsp_python.lua
+++ b/plugins/lsp_python.lua
@@ -1,0 +1,11 @@
+-- mod-version:3
+
+local lspconfig = require "plugins.lsp.config"
+local common = require "core.common"
+local config = require "core.config"
+
+local installed_path = USERDIR .. PATHSEP .. "plugins" .. PATHSEP .. "lsp_python"
+
+lspconfig.pyright.setup(common.merge({
+  command = {installed_path .. PATHSEP .. "package" .. PATHSEP .. "langserver.index.js", "--stdio"}
+}, config.plugins.lsp_python or {}))

--- a/plugins/lsp_python.lua
+++ b/plugins/lsp_python.lua
@@ -6,32 +6,22 @@ local config = require "core.config"
 local core = require "core"
 
 local installed_path_plugin = USERDIR .. PATHSEP .. "plugins" .. PATHSEP .. "lsp_python"
-local node_version = "node-v20.11.0"
-local installed_path_library = USERDIR .. PATHSEP .. "libraries" .. PATHSEP .. "nodejs"
+local installed_path_library = USERDIR .. PATHSEP .. "libraries" .. PATHSEP .. "nodejs" .. PATHSEP
 
 local server_path = installed_path_plugin .. PATHSEP .. "package" .. PATHSEP .. "langserver.index.js"
 
-local node_path
-if ARCH == "x86_64-linux" then
-  node_path = installed_path_library .. PATHSEP .. node_version .. "-linux-x64" .. PATHSEP .. "bin" .. PATHSEP .. "node"
-elseif ARCH == "x86_64-darwin" then
-  node_path = installed_path_library .. PATHSEP .. node_version .. "-darwin-x64" .. PATHSEP .. "bin" .. PATHSEP .. "node"
-elseif ARCH == "arm64-darwin" then
-  node_path = installed_path_library .. PATHSEP .. node_version .. "-darwin-arm64" .. PATHSEP .. "bin" .. PATHSEP .. "node"
-elseif ARCH == "x86_64-windows" then
-  node_path = installed_path_library .. PATHSEP .. node_version .. "-win-x64" .. PATHSEP .. "node.exe"
-end
 
+local ok, node_info = pcall(require, "libraries.nodejs")
 local final_command
-core.log(node_path)
-if system.get_file_info(node_path) == nil then
+
+if ok then
+  -- NodeJs installed with lpm, runs it instead.
+  final_command = {installed_path_library .. node_info.path, server_path, "--stdio"}
+  core.log("[lsp_python]: nodejs library found, using it to launch Pyright.")
+else
   -- NodeJs not installed with lpm, then tries to use the system path variable.
   final_command = {"node", server_path, "--stdio"}
   core.log("[lsp_python]: nodejs library not found, trying to use the 'node' path variable.")
-else
-  -- NodeJs installed with lpm, runs it instead.
-  final_command = {node_path, server_path, "--stdio"}
-  core.log("[lsp_python]: nodejs library found, using it to launch Pyright.")
 end
 
 

--- a/plugins/lsp_python.lua
+++ b/plugins/lsp_python.lua
@@ -5,7 +5,7 @@ local common = require "core.common"
 local config = require "core.config"
 
 local installed_path_plugin = USERDIR .. PATHSEP .. "plugins" .. PATHSEP .. "lsp_python"
-local installed_path_library = USERDIR .. PATHSEP .. "libraries" .. PATHSEP .. "node"
+local installed_path_library = USERDIR .. PATHSEP .. "libraries" .. PATHSEP .. "nodejs"
 
 local server_path = installed_path_plugin .. PATHSEP .. "package" .. PATHSEP .. "langserver.index.js"
 


### PR DESCRIPTION
The version of Pyright used here is the version packaged by Node-Js (hence the download link in `manifest.json` heading to their domain).

I am not sure about the checksum value, as this is the first time I am working with this. (I generated it form https://emn178.github.io/online-tools/sha256_checksum.html)

This PR should resolve #8 , even though it is not using the same server to do it. 