### PR TITLE
Add tsserver bundling

### DIFF
--- a/.github/workflows/typescript-language-server.yml
+++ b/.github/workflows/typescript-language-server.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Package
         run: |
           mkdir bundle
-          cp -r typescript-language-server-${VERSION}/{package.json,lib} bundle
+          cp -r typescript-language-server-${VERSION}/{package.json,lib,LICENSE} bundle
           mkdir -p bundle/node_modules/typescript
           cp -r package/* bundle/node_modules/typescript
           mv bundle tsserver

--- a/.github/workflows/typescript-language-server.yml
+++ b/.github/workflows/typescript-language-server.yml
@@ -1,11 +1,15 @@
 name: Package typescript-language-server
 
 on:
-  push:
-    tags:
-      - typescript-language-server-*
   workflow_dispatch:
-
+    inputs:
+      typescript-language-server_version:
+        type: string
+        required: true
+      tsserver_version:
+        type: string
+        required: false
+        default: "5.3.3"
 
 jobs:
   package_all:
@@ -13,16 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     env:
-      TS_VERSION: 5.3.3
+      VERSION: ${{ inputs.typescript-language-server_version }}
+      TS_VERSION: ${{ inputs.tsserver_version }}
     steps:
       - uses: actions/checkout@v3
       - name: Update Packages
         run: sudo apt-get update -y
       - name: Install Dependencies
         run: sudo apt-get install -y yarn
-      - name: Set version env
-        run: |
-          REF=${{ github.ref_name }}; echo "VERSION=${REF##*-}" >> "$GITHUB_ENV"
       - name: Get typescript-language-server
         run: |
           curl -L -o "v${VERSION}.tar.gz" "https://github.com/typescript-language-server/typescript-language-server/archive/refs/tags/v${VERSION}.tar.gz"
@@ -45,8 +47,8 @@ jobs:
           cp -r package/* bundle/node_modules/typescript
           mv bundle tsserver
           tar -zcvf tsserver-${VERSION}.tar.gz tsserver
-      - name: Create Release(s)
+      - name: Create Release
         env: { GITHUB_TOKEN: "${{ github.token }}" }
         run: |
-          gh release delete -y "${{ github.ref_name }}" || true
-          gh release create -t "${{ github.ref_name }}" "${{ github.ref_name }}" tsserver-${VERSION}.tar.gz
+          gh release delete -y "typescript-language-server-$VERSION" || true
+          gh release create -t "typescript-language-server-$VERSION" "typescript-language-server-$VERSION" "tsserver-${VERSION}.tar.gz"

--- a/.github/workflows/typescript-language-server.yml
+++ b/.github/workflows/typescript-language-server.yml
@@ -1,0 +1,52 @@
+name: Package typescript-language-server
+
+on:
+  push:
+    tags:
+      - typescript-language-server-*
+  workflow_dispatch:
+
+
+jobs:
+  package_all:
+    name: Package Typescript Language Server
+    runs-on: ubuntu-latest
+    permissions: write-all
+    env:
+      TS_VERSION: 5.3.3
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update Packages
+        run: sudo apt-get update -y
+      - name: Install Dependencies
+        run: sudo apt-get install -y yarn
+      - name: Set version env
+        run: |
+          REF=${{ github.ref_name }}; echo "VERSION=${REF##*-}" >> "$GITHUB_ENV"
+      - name: Get typescript-language-server
+        run: |
+          curl -L -o "v${VERSION}.tar.gz" "https://github.com/typescript-language-server/typescript-language-server/archive/refs/tags/v${VERSION}.tar.gz"
+      - name: Build typescript-language-server
+        run: |
+          tar -xzvf "v${VERSION}.tar.gz"
+          cd "typescript-language-server-${VERSION}"
+          yarn
+          yarn build
+          rm lib/cli.mjs.map
+      - name: Get Typescript
+        run: |
+          curl -L -o "typescript-${TS_VERSION}.tgz" "https://github.com/microsoft/TypeScript/releases/download/v5.3.3/typescript-${TS_VERSION}.tgz"
+          tar -xzvf "typescript-${TS_VERSION}.tgz"
+      - name: Package
+        run: |
+          mkdir bundle
+          cp -r typescript-language-server-${VERSION}/{package.json,lib} bundle
+          mkdir -p bundle/node_modules/typescript
+          cp -r package/* bundle/node_modules/typescript
+          mv bundle tsserver
+          tar -zcvf tsserver-${VERSION}.tar.gz tsserver
+      - name: Create Release(s)
+        env: { GITHUB_TOKEN: "${{ github.token }}" }
+        run: |
+          gh release delete -y "${{ github.ref_name }}" || true
+          gh release create -t "${{ github.ref_name }}" "${{ github.ref_name }}" tsserver-${VERSION}.tar.gz


### PR DESCRIPTION
This is an action that builds an archive with all that's needed for `typescript-language-server`.
That is, it builds `typescript-language-server` and bundles `tsserver` with it.
The bundle is then released under the name `typescript-language-server-$VERSION`.

Originally this was triggered by a tag named `typescript-language-server-$VERSION`, but I changed this to a `workflow_dispatch`-based approach, as it seems less convoluted.
Let me know if it was better with the tag approach.

This is the first part of two needed for `lsp_typescript`.